### PR TITLE
testing __init__ of base model with args

### DIFF
--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -28,3 +28,14 @@ class TestBaseModel(unittest.TestCase):
             os.remove("file.json")
         except:
             pass
+
+def test_init_with_insufficient_args(self):
+        with self.assertRaises(Exception):
+            base0 = BaseModel(number=89)
+
+    def test_init_with_sufficient_args(self):
+        self.assertEqual(self.base1.number, 89)
+        self.assertEqual(self.base1.created_at,
+                         datetime.datetime(2020, 06, 28T01, 25, 18, 335269))
+        self.assertEqual(self.base1.updated_at,
+                         datetime.datetime(2020, 06, 28T01, 25, 18, 335279))


### PR DESCRIPTION
testing the __init__ method in the base model with sufficient args and insufficient args

**didn't run the test though, as am tired now.  I will run the test tomorrow.

You can also help in running the test. Thanks mate.